### PR TITLE
#PNCA-340: Available assets to webhook

### DIFF
--- a/config.js
+++ b/config.js
@@ -142,6 +142,7 @@ config.s3UploadEverything = argv.s3_upload_everything || fromConfigFile("s3Uploa
 config.s3IgnoreSSL = argv.s3_ignore_ssl || fromConfigFile("s3IgnoreSSL", false);
 config.maxConcurrency = parseInt(argv.max_concurrency || fromConfigFile("maxConcurrency", 0));
 config.maxRuntime = parseInt(argv.max_runtime || fromConfigFile("maxRuntime", -1));
+config.allowedDownloadableAssets = ['**/*'];
 
 // Detect 7z availability
 config.has7z = spawnSync(apps.sevenZ, ['--help']).status === 0;

--- a/libs/Task.js
+++ b/libs/Task.js
@@ -23,6 +23,7 @@ const os = require('os');
 const assert = require('assert');
 const logger = require('./logger');
 const fs = require('fs');
+const glob = require("glob");
 const path = require('path');
 const rmdir = require('rimraf');
 const odmRunner = require('./odmRunner');
@@ -206,8 +207,36 @@ module.exports = class Task{
         }else{
             return false; // Invalid
         }
-        
         return path.join(this.getProjectFolderPath(), filename);
+    }
+
+    // Get the paths of outputted assets
+    getAllowedAssetPaths(pattern){
+        function arrayIntersection(firstArray, secondArray) {
+            return firstArray.filter(path => secondArray.includes(path))
+        }
+        function trimPaths(array) {
+            return array.map(path => path.split('/').splice(2, path.split('/').length).join('/'))
+        }
+        function filterOutFolderPaths(path) {
+            return /(?:\.([^.]+))?$/.exec(path)[1]
+        }
+        const allowedAssetPaths = this.getAssetPaths(config.allowedDownloadableAssets);
+        const requestedAssetPaths = this.getAssetPaths(pattern);
+        return trimPaths(arrayIntersection(allowedAssetPaths, requestedAssetPaths)).filter(filterOutFolderPaths);
+    }
+
+    getAssetPaths(pattern){
+        if (typeof pattern === 'undefined') {
+            return glob.sync(this.getProjectFolderPath() + '/**/*', {});
+        } else if (typeof pattern === 'string') {
+            return glob.sync(this.getProjectFolderPath() + '/' + pattern.replace(/^\//g, ''), {});
+        } else if (Array.isArray(pattern)) {
+            return pattern.map(patternString => this.getAssetPaths(patternString)).flat()
+        } else {
+            logger.error(`Unable to get asset paths with provided pattern: ${pattern}`);
+            return;
+        }
     }
 
     // Deletes files and folders related to this task
@@ -697,6 +726,7 @@ module.exports = class Task{
 
             let json = this.getInfo();
             json.images = images;
+            json.availableAssets = this.getAllowedAssetPaths();
 
             hooks.forEach(hook => {
                 if (hook && hook.length > 3){


### PR DESCRIPTION
## Features
- Webhook request now return available assets in json
- Created two helper methods for getting paths to files for generated files

## How to test
- Create a new submission and add enough images (at least 5)
- Check `node-OpenDroneMap.log` that NodeODM has received the task initialization and copy the `UUID` from the log
- Check the processing progress by using the [NodeODM `info` api](https://github.com/OpenDroneMap/NodeODM/blob/master/docs/index.adoc#get-taskuuidinfo) with copied task `UUID`
- Once the progess is `100` check `laravel.log`
  - There should be a array of all available assets as relative paths (only files, not folders)
  - eg. 
```
'availableAssets' => 
    array (
      0 => 'all.zip',
      1 => 'benchmark.txt',
      2 => 'cameras.json',
      3 => 'entwine_pointcloud/ept-build.json',
      4 => 'entwine_pointcloud/ept-data/0-0-0-0.laz',
      5 => 'entwine_pointcloud/ept-data/1-1-1-0.laz',
      6 => 'entwine_pointcloud/ept-data/2-3-2-0.laz',
      7 => 'entwine_pointcloud/ept-data/3-7-4-0.laz',
      8 => 'entwine_pointcloud/ept-data/3-7-5-0.laz',
      9 => 'entwine_pointcloud/ept-data/4-14-9-0.laz',
      10 => 'entwine_pointcloud/ept-data/4-15-10-1.laz',
      11 => 'entwine_pointcloud/ept-data/4-15-9-0.laz',
      12 => 'entwine_pointcloud/ept-data/5-30-18-0.laz',
      13 => 'entwine_pointcloud/ept-data/5-30-19-0.laz',
      14 => 'entwine_pointcloud/ept-data/5-30-19-1.laz',
      15 => 'entwine_pointcloud/ept-data/5-31-19-0.laz',
      16 => 'entwine_pointcloud/ept-hierarchy/0-0-0-0.json',
      17 => 'entwine_pointcloud/ept-sources/manifest.json',
      18 => 'entwine_pointcloud/ept-sources/odm_georeferenced_model.json',
      19 => 'entwine_pointcloud/ept.json',
      20 => 'images.json',
      21 => 'images/DSC05514.JPG',
      22 => 'images/DSC05515.JPG',
      23 => 'images/DSC05516.JPG',
      24 => 'images/DSC05517.JPG',
      25 => 'images/DSC05518.JPG',
      26 => 'images/DSC05519.JPG',
      27 => 'images/DSC05520.JPG',
      28 => 'img_list.txt',
      29 => 'log.json',
      30 => 'odm_filterpoints/point_cloud.ply',
      31 => 'odm_georeferencing/coords.txt',
      32 => 'odm_georeferencing/odm_georeferenced_model.boundary.json',
      33 => 'odm_georeferencing/odm_georeferenced_model.bounds.geojson',
      34 => 'odm_georeferencing/odm_georeferenced_model.bounds.gpkg',
      35 => 'odm_georeferencing/odm_georeferenced_model.info.json',
      36 => 'odm_georeferencing/odm_georeferenced_model.laz',
      37 => 'odm_georeferencing/odm_georeferenced_model.summary.json',
      38 => 'odm_georeferencing/odm_georeferencing_model_geo.txt',
      39 => 'odm_georeferencing/proj.txt',
      40 => 'odm_meshing/odm_25dmesh.mvs',
      41 => 'odm_meshing/odm_25dmesh.ply',
      42 => 'odm_meshing/odm_mesh.mvs',
      43 => 'odm_meshing/odm_mesh.ply',
      44 => 'odm_orthophoto/gdal_translate_log.txt',
      45 => 'odm_orthophoto/odm_orthophoto_corners.txt',
      46 => 'odm_orthophoto/odm_orthophoto_log.txt',
      47 => 'odm_orthophoto/odm_orthophoto_render.tif',
      48 => 'odm_orthophoto/odm_orthophoto.original.tif',
      49 => 'odm_orthophoto/odm_orthophoto.tif',
      50 => 'odm_report/report.pdf',
      51 => 'odm_report/shots.geojson',
      52 => 'odm_report/stats.json',
      53 => 'odm_texturing_25d/odm_textured_model_geo_material0000_map_Kd.png',
      54 => 'odm_texturing_25d/odm_textured_model_geo_material0001_map_Kd.png',
      55 => 'odm_texturing_25d/odm_textured_model_geo_material0002_map_Kd.png',
      56 => 'odm_texturing_25d/odm_textured_model_geo_material0003_map_Kd.png',
      57 => 'odm_texturing_25d/odm_textured_model_geo_material0004_map_Kd.png',
      58 => 'odm_texturing_25d/odm_textured_model_geo_material0005_map_Kd.png',
      59 => 'odm_texturing_25d/odm_textured_model_geo_material0006_map_Kd.png',
      60 => 'odm_texturing_25d/odm_textured_model_geo_material0007_map_Kd.png',
      61 => 'odm_texturing_25d/odm_textured_model_geo_material0008_map_Kd.png',
      62 => 'odm_texturing_25d/odm_textured_model_geo_material0009_map_Kd.png',
      63 => 'odm_texturing_25d/odm_textured_model_geo_material0010_map_Kd.png',
      64 => 'odm_texturing_25d/odm_textured_model_geo_material0011_map_Kd.png',
      65 => 'odm_texturing_25d/odm_textured_model_geo.conf',
      66 => 'odm_texturing_25d/odm_textured_model_geo.mtl',
      67 => 'odm_texturing_25d/odm_textured_model_geo.obj',
      68 => 'odm_texturing_25d/odm_textured_model.mtl',
      69 => 'odm_texturing/odm_textured_model_geo_material0000_map_Kd.png',
      70 => 'odm_texturing/odm_textured_model_geo_material0001_map_Kd.png',
      71 => 'odm_texturing/odm_textured_model_geo_material0002_map_Kd.png',
      72 => 'odm_texturing/odm_textured_model_geo_material0003_map_Kd.png',
      73 => 'odm_texturing/odm_textured_model_geo_material0004_map_Kd.png',
      74 => 'odm_texturing/odm_textured_model_geo_material0005_map_Kd.png',
      75 => 'odm_texturing/odm_textured_model_geo_material0006_map_Kd.png',
      76 => 'odm_texturing/odm_textured_model_geo_material0007_map_Kd.png',
      77 => 'odm_texturing/odm_textured_model_geo_material0008_map_Kd.png',
      78 => 'odm_texturing/odm_textured_model_geo_material0009_map_Kd.png',
      79 => 'odm_texturing/odm_textured_model_geo.conf',
      80 => 'odm_texturing/odm_textured_model_geo.mtl',
      81 => 'odm_texturing/odm_textured_model_geo.obj',
      82 => 'odm_texturing/odm_textured_model.mtl',
      83 => 'opensfm/camera_models.json',
      84 => 'opensfm/config.yaml',
      85 => 'opensfm/exif/DSC05514.JPG.exif',
      86 => 'opensfm/exif/DSC05515.JPG.exif',
      87 => 'opensfm/exif/DSC05516.JPG.exif',
      88 => 'opensfm/exif/DSC05517.JPG.exif',
      89 => 'opensfm/exif/DSC05518.JPG.exif',
      90 => 'opensfm/exif/DSC05519.JPG.exif',
      91 => 'opensfm/exif/DSC05520.JPG.exif',
      92 => 'opensfm/features/DSC05514.JPG.features.npz',
      93 => 'opensfm/features/DSC05515.JPG.features.npz',
      94 => 'opensfm/features/DSC05516.JPG.features.npz',
      95 => 'opensfm/features/DSC05517.JPG.features.npz',
      96 => 'opensfm/features/DSC05518.JPG.features.npz',
      97 => 'opensfm/features/DSC05519.JPG.features.npz',
      98 => 'opensfm/features/DSC05520.JPG.features.npz',
      99 => 'opensfm/image_list.txt',
      100 => 'opensfm/matches/DSC05514.JPG_matches.pkl.gz',
      101 => 'opensfm/matches/DSC05515.JPG_matches.pkl.gz',
      102 => 'opensfm/matches/DSC05516.JPG_matches.pkl.gz',
      103 => 'opensfm/matches/DSC05517.JPG_matches.pkl.gz',
      104 => 'opensfm/matches/DSC05518.JPG_matches.pkl.gz',
      105 => 'opensfm/matches/DSC05519.JPG_matches.pkl.gz',
      106 => 'opensfm/matches/DSC05520.JPG_matches.pkl.gz',
      107 => 'opensfm/profile.log',
      108 => 'opensfm/reconstruction.json',
      109 => 'opensfm/reconstruction.topocentric.json',
      110 => 'opensfm/reference_lla.json',
      111 => 'opensfm/reports/features.json',
      112 => 'opensfm/reports/features/DSC05514.JPG.json',
      113 => 'opensfm/reports/features/DSC05515.JPG.json',
      114 => 'opensfm/reports/features/DSC05516.JPG.json',
      115 => 'opensfm/reports/features/DSC05517.JPG.json',
      116 => 'opensfm/reports/features/DSC05518.JPG.json',
      117 => 'opensfm/reports/features/DSC05519.JPG.json',
      118 => 'opensfm/reports/features/DSC05520.JPG.json',
      119 => 'opensfm/reports/matches.json',
      120 => 'opensfm/reports/reconstruction.json',
      121 => 'opensfm/reports/tracks.json',
      122 => 'opensfm/stats/dsm_gradient.png',
      123 => 'opensfm/stats/heatmap_v2 sony dsc-hx5v 3648 2736 brown 0.6962.png',
      124 => 'opensfm/stats/matchgraph.png',
      125 => 'opensfm/stats/ortho.png',
      126 => 'opensfm/stats/ortho.png.aux.xml',
      127 => 'opensfm/stats/overlap_diagram_legend.png',
      128 => 'opensfm/stats/overlap.png',
      129 => 'opensfm/stats/overlap.png.aux.xml',
      130 => 'opensfm/stats/overlap.tif',
      131 => 'opensfm/stats/residual_histogram.png',
      132 => 'opensfm/stats/residuals_v2 sony dsc-hx5v 3648 2736 brown 0.6962.png',
      133 => 'opensfm/stats/stats.json',
      134 => 'opensfm/stats/topview.png',
      135 => 'opensfm/tracks.csv',
      136 => 'opensfm/undistorted/images/DSC05514.JPG.tif',
      137 => 'opensfm/undistorted/images/DSC05515.JPG.tif',
      138 => 'opensfm/undistorted/images/DSC05516.JPG.tif',
      139 => 'opensfm/undistorted/images/DSC05517.JPG.tif',
      140 => 'opensfm/undistorted/images/DSC05518.JPG.tif',
      141 => 'opensfm/undistorted/images/DSC05519.JPG.tif',
      142 => 'opensfm/undistorted/images/DSC05520.JPG.tif',
      143 => 'opensfm/undistorted/nominal_done.txt',
      144 => 'opensfm/undistorted/openmvs/Densify.ini',
      145 => 'opensfm/undistorted/openmvs/depthmaps/depth0000.dmap',
      146 => 'opensfm/undistorted/openmvs/depthmaps/depth0001.dmap',
      147 => 'opensfm/undistorted/openmvs/depthmaps/depth0002.dmap',
      148 => 'opensfm/undistorted/openmvs/depthmaps/depth0003.dmap',
      149 => 'opensfm/undistorted/openmvs/depthmaps/depth0004.dmap',
      150 => 'opensfm/undistorted/openmvs/depthmaps/depth0005.dmap',
      151 => 'opensfm/undistorted/openmvs/depthmaps/depth0006.dmap',
      152 => 'opensfm/undistorted/openmvs/scene_dense_dense_filtered.mvs',
      153 => 'opensfm/undistorted/openmvs/scene_dense_dense_filtered.ply',
      154 => 'opensfm/undistorted/openmvs/scene_dense.mvs',
      155 => 'opensfm/undistorted/openmvs/scene_dense.ply',
      156 => 'opensfm/undistorted/openmvs/scene.mvs',
      157 => 'opensfm/undistorted/reconstruction.json',
      158 => 'opensfm/undistorted/reconstruction.nvm',
      159 => 'opensfm/undistorted/tracks.csv',
      160 => 'opensfm/undistorted/undistorted_shot_ids.json',
      161 => 'opensfm/updated_config.txt',
      162 => 'task_output.txt',
    ),
```

**Modify wanted asset glob pattern**
- Open `libs/Task.js` file and go to line `729`
- Add glob pattern of wanted assets as parameter (it can be a single pattern or array of patterns)
  - eg. `this.getAllowedAssetPaths('odm_report/**/*');` or `this.getAllowedAssetPaths(['odm_report/**/*', 'odm_texturing_25d/**/*']);`
- Repeat all the steps above and check `laravel.log` that `availableAssets` now only contain files that were included in the glob pattern(s)  