### PR TITLE
#PNCA-341: Asset download api improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ app.get('/task/:uuid/output', authCheck, getTaskFromUuid, (req, res) => {
  *          schema:
  *            $ref: '#/definitions/Error'
  */
-app.get('/task/:uuid/download/:asset', authCheck, getTaskFromUuid, (req, res) => {
+app.get('/task/:uuid/download/:asset*', authCheck, getTaskFromUuid, (req, res) => {
     let asset = req.params.asset !== undefined ? req.params.asset : "all.zip";
     let filePath = req.task.getAssetsArchivePath(asset);
     if (filePath) {

--- a/index.js
+++ b/index.js
@@ -497,11 +497,11 @@ app.get('/task/:uuid/output', authCheck, getTaskFromUuid, (req, res) => {
  *            $ref: '#/definitions/Error'
  */
 app.get('/task/:uuid/download/:asset*', authCheck, getTaskFromUuid, (req, res) => {
-    let asset = req.params.asset !== undefined ? req.params.asset : "all.zip";
-    let filePath = req.task.getAssetsArchivePath(asset);
+    let filePath = req.task.getAssetPathFromRequest(req);
+    let fileName = req.task.getFileNameFromFilePath(filePath);
     if (filePath) {
         if (fs.existsSync(filePath)) {
-            res.setHeader('Content-Disposition', `attachment; filename=${asset}`);
+            res.setHeader('Content-Disposition', `attachment; filename=${fileName}`);
             res.setHeader('Content-Type', mime.getType(filePath));
             res.setHeader('Content-Length', fs.statSync(filePath).size);
 

--- a/libs/Task.js
+++ b/libs/Task.js
@@ -210,6 +210,21 @@ module.exports = class Task{
         return path.join(this.getProjectFolderPath(), filename);
     }
 
+    // Get asset path from request
+    getAssetPathFromRequest({ params }){
+        if (params) {
+            const {'0': wildcard, asset } = params;
+            return path.join(this.getProjectFolderPath(), `${asset}${wildcard}`);
+        } else {
+            return '';
+        }
+    }
+
+    // Get file name from file path
+    getFileNameFromFilePath(filePath){
+        return filePath.split('/')[filePath.split('/').length - 1]
+    }
+
     // Deletes files and folders related to this task
     cleanup(cb){
         if (this.initialized) rmdir(this.getProjectFolderPath(), cb);


### PR DESCRIPTION
## Features
- [NodeODM `download` api](https://github.com/OpenDroneMap/NodeODM/blob/master/docs/index.adoc#get-taskuuiddownloadasset) has been expanded to actually support all generated files


- Once this PR and https://github.com/tunnela/NodeODM/pull/2 has been merged to [`tunnela`](https://github.com/tunnela/NodeODM) I will create another PR so that requested file is also allowed to downloaded according to [config](https://github.com/tunnela/NodeODM/pull/2/files#diff-e8e9eea3276b2de9a74fd257902dc74c846f6fc8653bbddf45d738b71201f93d)

## How to test
- Create a new submission and add enough images (at least 5)
- Check `node-OpenDroneMap.log` that NodeODM has received the task initialization and copy the `UUID` from the log
- Check the processing progress by using the NodeODM `info` api with copied task `UUID`
- Once the progess is `100` test NodeODM download api with the task `UUID`
  - `/task/{uuid}/download/{asset}`
  - eg. `/task/1234-5678-9012-3456/download/odm_texturing/odm_textured_model_geo.obj`
- Test with different files and files inside of different folders 