### PR TITLE
#PNCA-346: Asset path security

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ app.get('/task/:uuid/output', authCheck, getTaskFromUuid, (req, res) => {
  *            $ref: '#/definitions/Error'
  */
 app.get('/task/:uuid/download/:asset*', authCheck, getTaskFromUuid, (req, res) => {
-    let filePath = req.task.getAssetPathFromRequest(req);
+    let filePath = req.task.getAllowedAssetPathFromRequest(config.allowedDownloadableAssets, req);
     let fileName = req.task.getFileNameFromFilePath(filePath);
     if (filePath) {
         if (fs.existsSync(filePath)) {
@@ -511,6 +511,7 @@ app.get('/task/:uuid/download/:asset*', authCheck, getTaskFromUuid, (req, res) =
             res.json({ error: "Asset not ready" });
         }
     } else {
+        logger.error("Invalid asset");
         res.json({ error: "Invalid asset" });
     }
 });


### PR DESCRIPTION
## Features
- Download api now checks if requested file is allowed to be downloaded (`config.js – config.allowedDownloadableAssets`)

## How to test
- Create a new submission and add enough images (at least 5)
- Check `node-OpenDroneMap.log` that NodeODM has received the task initialization and copy the `UUID` from the log
- Check the processing progress by using the NodeODM `info` api with copied task `UUID`
- Once the progess is `100` check submission data in the app
  - All assets should be listed in the app
<img width="495" alt="Screenshot 2022-12-07 at 21 04 08" src="https://user-images.githubusercontent.com/7174938/206272705-ab217f91-1c3a-4b2b-a035-8251f56a5db4.png">

- Open `config.js` and update the `allowedDownloadableAssets` property of the `config`
  - eg. `config.allowedDownloadableAssets = ['log.json'];`
  - Make sure that Node.js server process is restarted after changes to the config file
- Repeat all the steps above
  - There should be only allowed asset(s) listed in the app
<img width="486" alt="Screenshot 2022-12-07 at 21 03 55" src="https://user-images.githubusercontent.com/7174938/206272966-9709e92c-f1ec-4a54-8402-79c61426a492.png">
